### PR TITLE
fix line ending for windows systems in board initialisation

### DIFF
--- a/app/Game/Board.php
+++ b/app/Game/Board.php
@@ -59,7 +59,7 @@ final class Board
 ";
 
         // Base mask
-        $mask = collect(explode(PHP_EOL, trim($maskInput)))
+        $mask = collect(explode("\n", trim($maskInput)))
             ->map(fn (string $line) => collect(explode(' ', trim($line)))
                 ->map(fn (string $height) => array_fill(0, $height, true))
             );


### PR DESCRIPTION
Exploding the initial board string with PHP_EOL fails on windows systems because of the file's line separator