### PR TITLE
Return board early when no hints are available

### DIFF
--- a/app/Game/Board.php
+++ b/app/Game/Board.php
@@ -248,6 +248,10 @@ final class Board
             }
         }
 
+        if (empty($tileWithOpenMatch)) {
+            return $this;
+        }
+
         $matchingTile = null;
 
         foreach ($this->loop() as $tile) {
@@ -258,6 +262,10 @@ final class Board
                 $matchingTile = $tile;
                 break;
             }
+        }
+
+        if (empty($matchingTile)) {
+            return $this;
         }
 
         $tileWithOpenMatch->state = TileState::HIGHLIGHTED;


### PR DESCRIPTION
Asking for a hint when none are available throws an error. Now it returns the board without any hints.